### PR TITLE
Fix URL param parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,10 @@
     function getParams() {
       const url = new URL(window.location.href);
       const params = {};
-      for (const [k, v] of url.searchParams.entries()) params[k] = v;
+      for (const [k, v] of url.searchParams.entries()) {
+        // Replace + with spaces to handle form submissions correctly
+        params[k] = v.replace(/\+/g, ' ');
+      }
       return params;
     }
 


### PR DESCRIPTION
## Summary
- fix query parameter handling by replacing plus signs with spaces in `getParams`

## Testing
- `# no tests`

------
https://chatgpt.com/codex/tasks/task_b_68645aeb0f38832f8db16e0e4ec4c718