### PR TITLE
Fix repeated reveal due to double callback

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,7 +361,6 @@
               } else {
                 img.src = finalIcon;
                 img.style.transform = 'scale(1)';
-                if (callback && reel === reel3) setTimeout(callback, 300);
               }
               requestAnimationFrame(animate);
             } else {


### PR DESCRIPTION
## Summary
- ensure `showReveal()` only runs once by calling the callback at the end of the reel animation

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68645c2714b0832fb3a9cae50dd1813f