### PR TITLE
Remove shadow from instructions image

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,9 @@
       width: 97%; max-width: 340px; position: relative;
     }
     .instructions-image {
-      width: 100%; height: auto; border-radius: 12px; box-shadow: 0 2px 20px #0004;
+      width: 100%; height: auto; border-radius: 12px;
+      /* box-shadow: none; */
+      /* border: none; */
     }
     .tap-to-continue {
       position: absolute; bottom: -40px; left: 0; width: 100%; text-align: center;


### PR DESCRIPTION
## Summary
- remove the box shadow from `.instructions-image` so it appears without a surrounding box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6864607e9f40832f8eea6370479f2632