### PR TITLE
Improve reveal overlay pacing and style

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
       font-family: 'Poppins', sans-serif;
       color: #fff;
       text-shadow: -2px -2px 0 #A59079, 2px -2px 0 #A59079, -2px 2px 0 #A59079, 2px 2px 0 #A59079, 0px 3px 5px rgba(0,0,0,0.2);
-      margin-bottom: 0.32em;
+      margin-bottom: 1em;
       opacity: 0;
       transform: translateY(16px);
       transition: opacity 0.7s, transform 0.7s;
@@ -140,13 +140,20 @@
     .reveal-line.main { font-size: 2.15rem; font-weight: 900; margin-top: 0.16em;}
     .reveal-line.sub { font-size: 1.35rem; font-weight: 700; }
     .reveal-line.date { font-size: 1.14rem; font-weight: 700; }
-    .reveal-line.from { font-size: 1.13rem; font-weight: 700; font-style: italic; margin-top: 1.3em;}
+    .reveal-line.from {
+      font-size: 1rem;
+      font-weight: 700;
+      font-style: italic;
+      margin-top: 2.5em;
+      color: #fff;
+      text-shadow: -1px -1px 0 #A59079, 1px 1px 0 #A59079;
+    }
     @media (max-width:500px) {
       .aspect-container { max-width: 100vw; }
-      .reveal-line.main { font-size: 1.25rem;}
-      .reveal-line.sub { font-size: 1.09rem;}
-      .reveal-line.date { font-size: 1rem;}
-      .reveal-line.from { font-size: 0.95rem;}
+      .reveal-line.main { font-size: 1.05rem; }
+      .reveal-line.sub { font-size: 0.99rem; }
+      .reveal-line.date { font-size: 0.9rem; }
+      .reveal-line.from { font-size: 0.85rem; }
       .reveal-content { max-width: 99vw; }
     }
     .confetti { position: absolute; z-index: 101; will-change: transform, opacity; pointer-events: none; }
@@ -405,7 +412,7 @@
             revealLinesDiv.appendChild(div);
             setTimeout(() => div.classList.add('shown'), 70);
           }, delay);
-          delay += 720; // milliseconds between each line
+          delay += 1300; // milliseconds between each line
         });
 
         // 4. Show overlay and confetti


### PR DESCRIPTION
## Summary
- slow down staggered reveal timing in JS
- give more breathing room between overlay lines
- tweak sign-off styling for better readability
- reduce overlay font sizes on smaller screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686461862088832faa50f99fec7b35e5