### PR TITLE
Add optional photo reveal between lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,8 @@
     .reveal-line.photo img {
       width: 108px;
       height: 108px;
-      border-radius: 12px;
+      /* Rounded avatar style */
+      border-radius: 50%;
       object-fit: cover;
       margin-bottom: 1em;
       border: 4px solid #fff5;
@@ -230,10 +231,10 @@
       const sub = params.sub || "";
       const date = params.date || "";
       const from = params.from || "";
-      if (photo) lines.push({type: 'photo', content: photo});
       if (main) lines.push({type: 'main', content: main});
       if (sub) lines.push({type: 'sub', content: sub});
       if (date) lines.push({type: 'date', content: date});
+      if (photo) lines.push({type: 'photo', content: photo});
       if (from) lines.push({type: 'from', content: from});
       return lines;
     }


### PR DESCRIPTION
## Summary
- style photo as a circular avatar with subtle border/shadow
- show reveal lines in order: main, sub, date, photo, from
- keep fade in/slide animation and hide photo if it fails to load

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6864643eb648832fa8248a2b1bb3915f