### PR TITLE
Stagger photo reveal after main line

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,12 +421,22 @@
         }
 
         let lastDelay = 0;
-        // Display photo and main line immediately
+        // Show main line immediately
         revealLines.forEach(line => {
-          if (line.type === 'photo' || line.type === 'main') {
+          if (line.type === 'main') {
             lastDelay = Math.max(lastDelay, revealLine(line, 0));
           }
         });
+
+        // If a photo is present, reveal it slightly after the main line
+        const hasPhoto = revealLines.some(l => l.type === 'photo');
+        if (hasPhoto) {
+          revealLines.forEach(line => {
+            if (line.type === 'photo') {
+              lastDelay = Math.max(lastDelay, revealLine(line, 800));
+            }
+          });
+        }
 
         // Sub and date lines together after ~900ms
         revealLines.forEach(line => {


### PR DESCRIPTION
## Summary
- reveal the main line immediately
- when a photo is supplied, delay showing it for ~800ms
- keep existing timing for sub/date and from lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686469e444d4832f9422a52c161bf613