### PR TITLE
Prevent jump when reveal lines fade in

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
       flex-direction: column;
       align-items: center;
       width: 100%;
+      min-height: 20rem;
     }
     .reveal-line {
         width: 100%;
@@ -404,6 +405,32 @@
 
         // 2. Determine lines to reveal
         const revealLines = getRevealLinesFromParams(params);
+
+        // Calculate minimum height so lines can be inserted without layout shift
+        const tempContainer = document.createElement('div');
+        tempContainer.className = 'reveal-lines';
+        tempContainer.style.position = 'absolute';
+        tempContainer.style.visibility = 'hidden';
+        tempContainer.style.pointerEvents = 'none';
+        tempContainer.style.minHeight = '0';
+        document.body.appendChild(tempContainer);
+        revealLines.forEach(line => {
+          const div = document.createElement('div');
+          div.className = 'reveal-line ' + line.type;
+          if (line.type === 'photo') {
+            const img = document.createElement('img');
+            img.src = line.content;
+            div.appendChild(img);
+          } else {
+            div.textContent = line.content;
+          }
+          tempContainer.appendChild(div);
+        });
+        const targetHeight = tempContainer.offsetHeight;
+        document.body.removeChild(tempContainer);
+        const currentMin = parseFloat(getComputedStyle(revealLinesDiv).minHeight);
+        const finalHeight = Math.max(targetHeight, currentMin || 0);
+        revealLinesDiv.style.minHeight = finalHeight + 'px';
 
         // Helper to create and show a line
         function revealLine(line, delay) {


### PR DESCRIPTION
## Summary
- reserve vertical space for reveal lines via CSS min-height
- compute dynamic min-height and apply before animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68646d2eba40832f8a28a060b3a33a84