### PR TITLE
Improve overlay text outline and directions image

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@
         text-align: center;
         font-family: 'Poppins', sans-serif;
         color: #fff;
-        -webkit-text-stroke: 1px #A59079;
-        text-shadow: 0 0 1px rgba(0,0,0,0.2);
+        -webkit-text-stroke: 2px #A59079;
+        text-shadow: 0 0 2px rgba(0,0,0,0.2);
         margin-bottom: 1em;
         opacity: 0;
         transform: translateY(16px);
@@ -150,13 +150,13 @@
       font-style: italic;
       margin-top: 2.5em;
       color: #fff;
-      -webkit-text-stroke: 1px #A59079;
-      text-shadow: 0 0 1px rgba(0,0,0,0.2);
+      -webkit-text-stroke: 2px #A59079;
+      text-shadow: 0 0 2px rgba(0,0,0,0.2);
     }
     @media (max-width:500px) {
       .aspect-container { max-width: 100vw; }
       .reveal-line {
-        -webkit-text-stroke: 0.5px #A59079;
+        -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-line.main { font-size: 1.75rem; }
@@ -164,7 +164,7 @@
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
         font-size: 1.35rem;
-        -webkit-text-stroke: 0.5px #A59079;
+        -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-content { max-width: 99vw; }
@@ -181,7 +181,7 @@
       z-index: 20; cursor: pointer; transition: opacity 0.4s;
     }
     .instructions-container {
-      width: 97%; max-width: 340px; position: relative;
+      width: 97%; max-width: 380px; position: relative;
     }
     .instructions-image {
       width: 100%; height: auto; border-radius: 12px;


### PR DESCRIPTION
## Summary
- thicken outline on reveal text for better readability
- enlarge instructions image so the tutorial overlay is easier to read

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68646d958628832fa62c99f2abd6368b