### PR TITLE
Enhance reveal defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ xdg-open index.html        # Linux
 
 `index.html` supports several query parameters so you can customize the reveal text and appearance. Parameters are optional and can be combined:
 
-- `main` – main headline (default: "We're Expecting!")
+- `main` – main headline (default: "We are expecting!")
 - `sub` – secondary line of text
 - `date` – additional date or detail line
 - `photo` – URL to an image shown as a circular avatar

--- a/index.html
+++ b/index.html
@@ -114,6 +114,15 @@
       width: 100%;
       min-height: 20rem;
     }
+    .reveal-lines.big-main {
+      min-height: 100%;
+      justify-content: center;
+    }
+    .reveal-lines.big-main .reveal-line.main {
+      font-size: clamp(3rem, 12vw, 6rem);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
     .reveal-line {
         width: 100%;
         text-align: center;
@@ -142,7 +151,12 @@
       background: #f6f6f6;
       box-shadow: 0 2px 16px #0002;
     }
-    .reveal-line.main { font-size: 2.15rem; font-weight: 900; margin-top: 0.16em;}
+    .reveal-line.main {
+      font-size: 2.15rem;
+      font-weight: 900;
+      margin-top: 0.16em;
+      text-transform: uppercase;
+    }
     .reveal-line.sub { font-size: 1.35rem; font-weight: 700; }
     .reveal-line.date { font-size: 1.14rem; font-weight: 700; }
     .reveal-line.from {
@@ -151,7 +165,7 @@
       font-style: italic;
       margin-top: 2.5em;
       color: #fff;
-      -webkit-text-stroke: 2px #A59079;
+      -webkit-text-stroke: 2px #4A4A4A;
       text-shadow: 0 0 2px rgba(0,0,0,0.2);
     }
     @media (max-width:500px) {
@@ -165,7 +179,7 @@
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
         font-size: 1.35rem;
-        -webkit-text-stroke: 1px #A59079;
+        -webkit-text-stroke: 1px #4A4A4A;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-content { max-width: 99vw; }
@@ -234,7 +248,7 @@
       if (photo && !/^https?:|^data:/i.test(photo)) {
         photo = '';
       }
-      const main = params.main || "We're Expecting!";
+      const main = params.main || "We are expecting!";
       const sub = params.sub || "";
       const date = params.date || "";
       const from = params.from || "";
@@ -405,6 +419,11 @@
 
         // 2. Determine lines to reveal
         const revealLines = getRevealLinesFromParams(params);
+
+        const singleDefault = revealLines.length === 1 &&
+          revealLines[0].type === 'main' &&
+          revealLines[0].content.trim().toLowerCase() === 'we are expecting!';
+        revealLinesDiv.classList.toggle('big-main', singleDefault);
 
         // Calculate minimum height so lines can be inserted without layout shift
         const tempContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- enlarge single default reveal
- make the main line uppercase automatically
- darken text outlines
- update documentation for new default text

## Testing
- `tidy -e index.html` *(fails: command not found)*
- `htmlhint index.html` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686471cc4bec832fb22356bdf3757d89