### PR TITLE
Reduce reveal text outline thickness

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         text-align: center;
         font-family: 'Poppins', sans-serif;
         color: #fff;
-        -webkit-text-stroke: 1.5px #4A4A4A;
+        -webkit-text-stroke: 1px #4A4A4A;
         text-shadow: 0 0 2px rgba(0,0,0,0.2);
         margin-bottom: 1em;
         opacity: 0;
@@ -151,13 +151,13 @@
       font-style: italic;
       margin-top: 2.5em;
       color: #fff;
-      -webkit-text-stroke: 1px #A59079;
+      -webkit-text-stroke: 0.75px #A59079;
       text-shadow: 0 0 2px rgba(0,0,0,0.2);
     }
     @media (max-width:500px) {
       .aspect-container { max-width: 100vw; }
       .reveal-line {
-        -webkit-text-stroke: 1px #4A4A4A;
+        -webkit-text-stroke: 0.75px #4A4A4A;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-line.main { font-size: 1.75rem; }
@@ -165,7 +165,7 @@
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
         font-size: 1.35rem;
-        -webkit-text-stroke: 0.75px #A59079;
+        -webkit-text-stroke: 0.5px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-content { max-width: 99vw; }

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         text-align: center;
         font-family: 'Poppins', sans-serif;
         color: #fff;
-        -webkit-text-stroke: 2.5px #4A4A4A;
+        -webkit-text-stroke: 1.5px #4A4A4A;
         text-shadow: 0 0 2px rgba(0,0,0,0.2);
         margin-bottom: 1em;
         opacity: 0;
@@ -151,13 +151,13 @@
       font-style: italic;
       margin-top: 2.5em;
       color: #fff;
-      -webkit-text-stroke: 2px #A59079;
+      -webkit-text-stroke: 1px #A59079;
       text-shadow: 0 0 2px rgba(0,0,0,0.2);
     }
     @media (max-width:500px) {
       .aspect-container { max-width: 100vw; }
       .reveal-line {
-        -webkit-text-stroke: 1.5px #4A4A4A;
+        -webkit-text-stroke: 1px #4A4A4A;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-line.main { font-size: 1.75rem; }
@@ -165,7 +165,7 @@
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
         font-size: 1.35rem;
-        -webkit-text-stroke: 1px #A59079;
+        -webkit-text-stroke: 0.75px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-content { max-width: 99vw; }


### PR DESCRIPTION
## Summary
- lighten outline around reveal lines so it's not as thick on desktop and mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6864723f1084832f9532ee37f2847706