### PR TITLE
Fix overlay size on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,10 @@
     }
     .aspect-container {
       position: relative;
-      width: 98vw;
+      width: min(98vw, calc(98vh * 9 / 16));
       max-width: 430px;
       aspect-ratio: 9/16;
+      height: auto;
       background: #ddd;
       box-shadow: 0 6px 24px rgba(0,0,0,0.13);
       overflow: hidden;


### PR DESCRIPTION
## Summary
- prevent the main reveal container from exceeding the viewport

## Testing
- `No tests specified`

------
https://chatgpt.com/codex/tasks/task_b_6864741c6cf4832f93e6c05e26f4a1f9