### PR TITLE
Fix reveal line outline style

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
         text-align: center;
         font-family: 'Poppins', sans-serif;
         color: #fff;
-        -webkit-text-stroke: 2.5px #4A4A4A;
-        text-shadow: 0 0 2px rgba(0,0,0,0.2);
+        -webkit-text-stroke: 1px #A59079;
+        text-shadow: 0 0 1px rgba(0,0,0,0.2);
         margin-bottom: 1em;
         opacity: 0;
         transform: translateY(16px);
@@ -165,13 +165,13 @@
       font-style: italic;
       margin-top: 2.5em;
       color: #fff;
-      -webkit-text-stroke: 2px #4A4A4A;
-      text-shadow: 0 0 2px rgba(0,0,0,0.2);
+      -webkit-text-stroke: 1px #A59079;
+      text-shadow: 0 0 1px rgba(0,0,0,0.2);
     }
     @media (max-width:500px) {
       .aspect-container { max-width: 100vw; }
       .reveal-line {
-        -webkit-text-stroke: 1.5px #4A4A4A;
+        -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-line.main { font-size: 1.75rem; }
@@ -179,7 +179,7 @@
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
         font-size: 1.35rem;
-        -webkit-text-stroke: 1px #4A4A4A;
+        -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
       .reveal-content { max-width: 99vw; }


### PR DESCRIPTION
## Summary
- restore text outline thickness and color across reveal lines
- keep text shadow effect consistent on desktop and mobile
- keep desktop and mobile font sizes for the main and sub lines

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686474dd1c68832fb92dc0d7550bce3c