### PR TITLE
Fix reveal text overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,8 @@
     .reveal-line {
         width: 100%;
         text-align: center;
+        overflow-wrap: anywhere;
+        word-break: break-word;
         font-family: 'Poppins', sans-serif;
         color: #fff;
         -webkit-text-stroke: 1px #A59079;


### PR DESCRIPTION
## Summary
- prevent the default reveal line from being cut off on desktop by allowing long words to wrap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6864757936f4832fa59ebb6ca17868d6