### PR TITLE
Improve reveal font scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,8 +127,9 @@
     .reveal-line {
         width: 100%;
         text-align: center;
-        white-space: nowrap;
-        overflow: hidden;
+        white-space: normal;
+        word-break: keep-all;
+        overflow-wrap: normal;
         font-family: 'Poppins', sans-serif;
         color: #fff;
         -webkit-text-stroke: 1px #A59079;
@@ -307,9 +308,12 @@
             !line.classList.contains('sub') &&
             !line.classList.contains('from')) return;
         const isMobile = window.innerWidth <= 500;
-        const maxSizes = isMobile ? { main: 1.75, sub: 1.35, from: 1.35 } :
-                                   { main: 2.15, sub: 1.35, from: 1.3 };
-        const minSize = isMobile ? 1 : 1.2;
+        const maxSizes = isMobile ?
+          { main: 1.75, sub: 1.35, from: 1.35 } :
+          { main: 2.15, sub: 1.35, from: 1.3 };
+        const minSizes = isMobile ?
+          { main: 1, sub: 0.85, from: 0.85 } :
+          { main: 1.2, sub: 1, from: 1 };
         const type = line.classList.contains('main') ? 'main' :
                      line.classList.contains('sub') ? 'sub' : 'from';
         let size = maxSizes[type];
@@ -317,7 +321,7 @@
         const containerWidth = line.parentElement.clientWidth;
         const width = line.scrollWidth;
         if (width > containerWidth) {
-          size = Math.max(minSize, size * containerWidth / width);
+          size = Math.max(minSizes[type], size * containerWidth / width);
           line.style.fontSize = size + 'rem';
         }
       }


### PR DESCRIPTION
## Summary
- allow reveal lines to wrap and keep words intact
- fine tune JS font scaling for main, sub and from text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686478d906e8832fb8fc0e2bdf00b46b