### PR TITLE
Responsive headline wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,18 +169,19 @@
       box-shadow: 0 2px 16px #0002;
     }
     .reveal-line.main {
-      font-size: clamp(2rem, 6vw, 5.5rem);
+      font-size: clamp(4rem, 15vw, 200rem);
+      line-height: 1.15;
       font-weight: 900;
       margin-top: 0.16em;
       text-transform: uppercase;
     }
     .reveal-line.sub {
-      font-size: clamp(1.25rem, 4.5vw, 3rem);
+      font-size: clamp(2.5rem, 10vw, 100rem);
       font-weight: 700;
     }
     .reveal-line.date { font-size: 1.14rem; font-weight: 700; }
     .reveal-line.from {
-      font-size: clamp(1.25rem, 4.5vw, 3rem);
+      font-size: clamp(2.2rem, 8vw, 80rem);
       font-weight: 700;
       font-style: italic;
       margin-top: 2.5em;
@@ -194,11 +195,11 @@
         -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
-      .reveal-line.main { font-size: clamp(1.5rem, 10vw, 4rem); }
-      .reveal-line.sub { font-size: clamp(1.1rem, 6vw, 2.4rem); }
+      .reveal-line.main { font-size: clamp(3rem, 20vw, 200rem); }
+      .reveal-line.sub { font-size: clamp(2rem, 14vw, 100rem); }
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
-        font-size: clamp(1.1rem, 6vw, 2.4rem);
+        font-size: clamp(1.8rem, 12vw, 80rem);
         -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
@@ -330,22 +331,15 @@
         if (!line.classList.contains('main') &&
             !line.classList.contains('sub') &&
             !line.classList.contains('from')) return;
-        const isMobile = window.innerWidth <= 500;
-        const maxSizes = isMobile ?
-          { main: 4, sub: 2.4, from: 2.4 } :
-          { main: 5.5, sub: 3, from: 3 };
-        const minSizes = { main: 1, sub: 0.8, from: 0.8 };
-        const type = line.classList.contains('main') ? 'main' :
-                     line.classList.contains('sub') ? 'sub' : 'from';
-        let size = maxSizes[type];
+        const rootSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+        let size = parseFloat(getComputedStyle(line).fontSize) / rootSize;
+        const container = line.parentElement;
+        const w = container.clientWidth - 4;
+        const h = container.clientHeight || revealOverlay.clientHeight;
         line.style.fontSize = size + 'rem';
-        const containerWidth = line.parentElement.clientWidth - 8;
-        if (line.scrollWidth > containerWidth) {
-          size *= containerWidth / line.scrollWidth;
+        while ((line.scrollWidth > w || line.scrollHeight > h) && size > 0.5) {
+          size -= 0.25;
           line.style.fontSize = size + 'rem';
-        }
-        if (size < minSizes[type]) {
-          line.style.fontSize = minSizes[type] + 'rem';
         }
       }
 


### PR DESCRIPTION
## Summary
- expand main/sub/from font sizes so they can grow huge but wrap
- remove hard font ceilings in JS and shrink text only when overflowing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686488f49510832f81ee24f8f771acf5