### PR TITLE
Improve reveal sizing for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
       box-shadow: 0 2px 16px #0002;
     }
     .reveal-line.main {
-      font-size: clamp(4rem, 15vw, 200rem);
+      font-size: clamp(4rem, 18vw, 999rem);
       line-height: 1.15;
       font-weight: 900;
       margin-top: 0.16em;
@@ -195,7 +195,7 @@
         -webkit-text-stroke: 1px #A59079;
         text-shadow: 0 0 1px rgba(0,0,0,0.15);
       }
-      .reveal-line.main { font-size: clamp(3rem, 20vw, 200rem); }
+      .reveal-line.main { font-size: clamp(3.2rem, 24vw, 999rem); }
       .reveal-line.sub { font-size: clamp(2rem, 14vw, 100rem); }
       .reveal-line.date { font-size: 1.25rem; }
       .reveal-line.from {
@@ -341,6 +341,15 @@
           size -= 0.25;
           line.style.fontSize = size + 'rem';
         }
+        // Grow text if it still looks too small after shrinking
+        while (line.scrollWidth < w * 0.9 && line.scrollHeight < h * 0.7) {
+          const prev = parseFloat(getComputedStyle(line).fontSize) / rootSize;
+          size += 0.25;
+          line.style.fontSize = size + 'rem';
+          const computed = parseFloat(getComputedStyle(line).fontSize) / rootSize;
+          if (computed <= prev) { size -= 0.25; line.style.fontSize = size + 'rem'; break; }
+          if (line.scrollWidth > w || line.scrollHeight > h) { size -= 0.25; line.style.fontSize = size + 'rem'; break; }
+        }
       }
 
       function resizeRevealText() {
@@ -360,7 +369,7 @@
       }
 
       function fitIntroText() {
-        let size = window.innerWidth <= 500 ? 8 : 12;
+        let size = window.innerWidth <= 500 ? 14 : 18;
         introMessage.style.fontSize = size + 'rem';
         const container = introOverlay;
         while ((introMessage.scrollWidth > container.clientWidth * 0.9 ||


### PR DESCRIPTION
## Summary
- enlarge intro font start sizes for better fit
- increase main headline clamp sizes for desktop and mobile
- ensure lines grow if they appear too small after shrinking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68648b8ec8a0832fb584f92d5791ed44