### PR TITLE
Improve reveal flow and text fitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,19 +452,41 @@
           window.webkitAudioContext)();
 
         function fitRevealLine(line) {
-          if (!line.classList.contains("main") && !line.classList.contains("sub") && !line.classList.contains("from")) return;
-          const rootSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
-          let size = parseFloat(getComputedStyle(line).fontSize) / rootSize;
+          if (
+            !line.classList.contains("main") &&
+            !line.classList.contains("sub") &&
+            !line.classList.contains("from")
+          )
+            return;
+          const rootSize = parseFloat(
+            getComputedStyle(document.documentElement).fontSize,
+          );
+          let size =
+            parseFloat(getComputedStyle(line).fontSize) / rootSize || 1;
           const container = line.parentElement;
-          const maxSize = 150;
           line.style.fontSize = size + "rem";
-          while ((line.scrollWidth > container.clientWidth || line.scrollHeight > container.clientHeight) && size > 0.5) {
+          while (
+            (line.scrollWidth > container.clientWidth ||
+              line.scrollHeight > container.clientHeight) &&
+            size > 0.5
+          ) {
             size -= 0.25;
             line.style.fontSize = size + "rem";
           }
-          while (size < maxSize && line.scrollWidth <= container.clientWidth * 0.95 && line.scrollHeight <= container.clientHeight * 0.9) {
+          while (
+            line.scrollWidth <= container.clientWidth &&
+            line.scrollHeight <= container.clientHeight
+          ) {
             size += 0.25;
             line.style.fontSize = size + "rem";
+            if (
+              line.scrollWidth > container.clientWidth ||
+              line.scrollHeight > container.clientHeight
+            ) {
+              size -= 0.25;
+              line.style.fontSize = size + "rem";
+              break;
+            }
           }
         }
 
@@ -478,12 +500,8 @@
           lines.forEach(fitRevealLine);
           const availableHeight = revealOverlay.clientHeight * 0.9;
           const totalHeight = revealLinesDiv.scrollHeight;
-          if (
-            totalHeight > 0 &&
-            (totalHeight > availableHeight ||
-              totalHeight < availableHeight * 0.7)
-          ) {
-            const scale = Math.min(availableHeight / totalHeight, 1.3);
+          if (totalHeight > 0) {
+            const scale = availableHeight / totalHeight;
             lines.forEach((line) => {
               const current = parseFloat(line.style.fontSize);
               line.style.fontSize = current * scale + "rem";
@@ -492,16 +510,31 @@
         }
 
         function fitIntroText() {
-          let size = window.innerWidth <= 500 ? 14 : 18;
+          let size = window.innerWidth <= 500 ? 18 : 24;
           introMessage.style.fontSize = size + "rem";
           const container = introOverlay;
           while (
-            (introMessage.scrollWidth > container.clientWidth * 0.9 ||
-              introMessage.scrollHeight > container.clientHeight * 0.9) &&
+            (introMessage.scrollWidth > container.clientWidth ||
+              introMessage.scrollHeight > container.clientHeight) &&
             size > 1
           ) {
             size -= 0.5;
             introMessage.style.fontSize = size + "rem";
+          }
+          while (
+            introMessage.scrollWidth <= container.clientWidth &&
+            introMessage.scrollHeight <= container.clientHeight
+          ) {
+            size += 0.5;
+            introMessage.style.fontSize = size + "rem";
+            if (
+              introMessage.scrollWidth > container.clientWidth ||
+              introMessage.scrollHeight > container.clientHeight
+            ) {
+              size -= 0.5;
+              introMessage.style.fontSize = size + "rem";
+              break;
+            }
           }
         }
 
@@ -699,7 +732,7 @@
               else revealLine(step, delay);
               delay += 900;
             });
-            const hideDelay = delay + 4000;
+            const hideDelay = 30000;
 
 
 
@@ -727,21 +760,11 @@
             function proceed() {
               introOverlay.style.opacity = "0";
               introOverlay.style.pointerEvents = "none";
-              introOverlay.removeEventListener("click", proceed);
-              introOverlay.removeEventListener("touchstart", proceed);
               revealOverlay.style.opacity = "1";
               revealOverlay.style.pointerEvents = "auto";
               setTimeout(showStageTwo, 100);
             }
-            introOverlay.addEventListener("click", proceed);
-            introOverlay.addEventListener(
-              "touchstart",
-              function (e) {
-                e.preventDefault();
-                proceed();
-              },
-              { passive: false },
-            );
+            setTimeout(proceed, 800);
           } else {
             revealOverlay.style.opacity = "1";
             revealOverlay.style.pointerEvents = "auto";


### PR DESCRIPTION
## Summary
- automatically advance from intro to reveal after 800 ms
- keep reveal visible for 30 s before fading
- expand text to fill overlays with no hard size ceilings

## Testing
- `tidy -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68649fffe9ec832faeea5988846b9e92