### PR TITLE
Stop jumpy reveal resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,7 @@
         const params = getParams();
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
+        let minHeightLocked = false;
 
         function fitRevealLine(line) {
           if (
@@ -506,6 +507,11 @@
               const current = parseFloat(line.style.fontSize);
               line.style.fontSize = current * scale + "rem";
             });
+          }
+          const targetHeight = revealLinesDiv.scrollHeight;
+          if (!minHeightLocked) {
+            revealLinesDiv.style.minHeight = targetHeight + "px";
+            minHeightLocked = true;
           }
         }
 
@@ -721,8 +727,6 @@
                   div.textContent = line.content;
                 }
                 revealLinesDiv.appendChild(div);
-                fitRevealLine(div);
-                resizeRevealText();
                 requestAnimationFrame(() => {
                   div.classList.add("shown");
                 });
@@ -739,6 +743,8 @@
               else revealLine(step, delay);
               delay += 900;
             });
+            // Wait until all lines are in the DOM, then size everything once
+            setTimeout(resizeRevealText, delay);
             const hideDelay = 30000;
 
 


### PR DESCRIPTION
## Summary
- avoid repeated resizing while lines fade in
- size reveal text once after all lines are in the DOM
- lock the reveal line container height to prevent upward jumps

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6864a791fcd4832f89fea82ca79476a5