### PR TITLE
Fix overlay centering and allow fitty to size text

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,9 @@
         transition: opacity 0.2s;
         flex-direction: column;
       }
+      #revealOverlay {
+        height: 100vh;
+      }
       .reveal-overlay .color-overlay,
       .intro-overlay .color-overlay {
         position: absolute;
@@ -184,7 +187,6 @@
         z-index: 2;
         width: 90%;
         text-align: center;
-        font-size: clamp(2.5rem, 12vw, 7rem);
         font-weight: 900;
         text-transform: uppercase;
         color: #fff;
@@ -202,13 +204,16 @@
         flex-direction: column;
         align-items: center;
       }
-      .reveal-lines{
-        display:flex;
-        flex-direction:column;
-        justify-content:space-evenly;   /* even vertical spacing */
-        align-items:center;
-        height:100%;                    /* fill overlay vertically */
-        gap:clamp(.5rem,4vh,1.2rem);    /* responsive breathing room */
+      .reveal-lines {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
+        gap: clamp(0.5rem, 4vh, 1.2rem);
+      }
+      #revealOverlay .reveal-lines {
+        height: 100%;
       }
 
       .reveal-stage2 .reveal-lines{
@@ -242,9 +247,8 @@
       }
 
 
-      .reveal-stage2 .reveal-line{
-        line-height:1.15;
-        font-size: clamp(1.8rem, 7vw, 3.4rem);
+      .reveal-stage2 .reveal-line {
+        line-height: 1.15;
       }
       .reveal-line.photo img {
         width: 96px;
@@ -260,28 +264,23 @@
         margin: 1.2rem 0;
       }
       .reveal-line.main {
-        font-size: clamp(4rem, 22vw, 150rem);
-        line-height:1.1;
+        line-height: 1.1;
         font-weight: 900;
-        margin-top: 0.16em;
         text-transform: uppercase;
       }
       .reveal-line.sub {
-        font-size: clamp(2.5rem, 12vw, 7rem);
         font-weight: 700;
       }
       .reveal-stage2 .reveal-line.sub {
         text-transform: uppercase;
       }
       .reveal-line.date {
-        font-size: clamp(2.5rem, 12vw, 7rem);
         font-weight: 700;
       }
       .reveal-line.from {
-        font-size: clamp(2.5rem, 12vw, 7rem);
         font-weight: 700;
         font-style: italic;
-        margin-top: 2.5em;
+        margin-top: 0;
         color: #fff;
         -webkit-text-stroke: 1px #a59079;
         text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
@@ -295,7 +294,6 @@
           text-shadow: 0 0 1px rgba(0, 0, 0, 0.15);
         }
         .reveal-stage2 .reveal-line {
-          font-size: clamp(1.6rem, 7.5vw, 2.8rem);
           line-height: 1.15;
         }
 
@@ -304,12 +302,10 @@
           padding: 1rem 0;    /* add top and bottom breathing room */
         }
         .reveal-line.main {
-          font-size: clamp(2rem, 12vw, 8rem);
         }
         .reveal-line.sub,
         .reveal-line.date,
         .reveal-line.from {
-          font-size: clamp(1.4rem, 8vw, 5rem);
         }
         .reveal-content {
           max-width: 99vw;


### PR DESCRIPTION
## Summary
- ensure the reveal overlay fills the viewport
- center `.reveal-lines` with flexbox and remove margins
- drop hardcoded font sizes so fitty controls text sizing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68654f227a1c832faff1b34f4a1df4d1