### PR TITLE
Tune Stage-2 reveal line fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,8 +185,10 @@
       .intro-message {
         position: relative;
         z-index: 2;
-        width: 90%;
+        width: 100%;
         text-align: center;
+        font-size: clamp(2rem, 12vw, 8rem);
+        line-height: 1.1;
         font-weight: 900;
         text-transform: uppercase;
         color: #fff;
@@ -248,6 +250,7 @@
 
 
       .reveal-stage2 .reveal-line {
+        font-size: clamp(1.8rem, 7vw, 3.4rem);
         line-height: 1.15;
       }
       .reveal-line.photo img {
@@ -294,6 +297,7 @@
           text-shadow: 0 0 1px rgba(0, 0, 0, 0.15);
         }
         .reveal-stage2 .reveal-line {
+          font-size: clamp(1.6rem, 7.5vw, 2.8rem);
           line-height: 1.15;
         }
 


### PR DESCRIPTION
## Summary
- reduce `.reveal-stage2 .reveal-line` font clamp for desktop
- lower the clamp for mobile view
- enlarge Stage‑1 intro message text so it fills the screen

## Testing
- `grep -n "font-size" -n index.html`


------
https://chatgpt.com/codex/tasks/task_b_68655aef2c5c832f887530d210e9f08c