### PR TITLE
Switch text sizing to textFit

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap"
       rel="stylesheet"
     />
-    <script src="https://unpkg.com/fitty/dist/fitty.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/textfit/2.4.0/textFit.min.js"></script>
     <style>
       html,
       body {
@@ -552,11 +552,13 @@
 
         function fitRevealLine(el, type) {
           if (type === "photo") return;
-          fitty(el, {
-            minSize: 16,
-            maxSize: 100,
+          textFit(el, {
+            alignVert: true,
+            alignHoriz: true,
             multiLine: true,
-            observeMutations: false,
+            detectMultiLine: true,
+            minFontSize: 12,
+            maxFontSize: 160,
           });
         }
 


### PR DESCRIPTION
## Summary
- remove Fitty dependency
- use `textFit` to size lines after they're inserted

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68656fb0a88c832fa9166e99bdc50864