### PR TITLE
Add mobile-only overlay margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,6 +149,7 @@
         left: 0;
         width: 100%;
         height: 100%;
+        border-radius: inherit;
         z-index: 1;
         pointer-events: none;
         opacity: 0.53;
@@ -221,6 +222,13 @@
         }
         .instructions-container {
           max-width: 96vw;
+        }
+        .reveal-overlay {
+          top: 2%;
+          left: 2%;
+          width: 96%;
+          height: 96%;
+          border-radius: 14px;
         }
       }
       .confetti {


### PR DESCRIPTION
## Summary
- revert global overlay layout to use full container
- apply margin and rounded corners for `.reveal-overlay` only on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68657c402eb8832fa9ae4bc305d47858