### PR TITLE
Remove border from overlay color

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,13 @@
         .instructions-container {
           max-width: 96vw;
         }
+        .reveal-overlay {
+          top: 2%;
+          left: 2%;
+          width: 96%;
+          height: 96%;
+          border-radius: 14px;
+        }
       }
       .confetti {
         position: absolute;


### PR DESCRIPTION
## Summary
- revert border-radius on `.reveal-overlay .color-overlay`
- keep mobile overlay padding and rounding

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68657c402eb8832fa9ae4bc305d47858