### PR TITLE
Fix overlay gap on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,11 +224,11 @@
           max-width: 96vw;
         }
         .reveal-overlay {
-          top: 2%;
-          left: 2%;
-          width: 96%;
-          height: 96%;
-          border-radius: 14px;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          border-radius: 0;
         }
       }
       .confetti {


### PR DESCRIPTION
## Summary
- make the reveal overlay full-screen on small displays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686582a9e8f4832f8caff0fefe712ca9