### PR TITLE
Adjust mobile reveal padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,8 @@
         width: 100%;
         height: 100%;
         gap: 2vh;
+        padding: 2vh 3vw;
+        box-sizing: border-box;
       }
 
       .reveal-line {
@@ -229,6 +231,9 @@
           width: 100%;
           height: 100%;
           border-radius: 0;
+        }
+        .reveal-lines {
+          padding-top: calc(2vh + env(safe-area-inset-top, 1vh));
         }
       }
       .confetti {


### PR DESCRIPTION
## Summary
- avoid mobile URL bars cutting off the reveal text
- add consistent padding around reveal text on all screens

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_6865853fc180832f8b09645b22b4fbfb