### PR TITLE
Fix overlay text stacking

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
         left: 0;
         width: 100%;
         height: 100%;
-        background-color: rgba(238, 222, 197, 0.93);
+        background-color: transparent;
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -150,7 +150,7 @@
         width: 100%;
         height: 100%;
         border-radius: inherit;
-        z-index: 1;
+        z-index: 0;
         pointer-events: none;
         opacity: 0.53;
         background: transparent;
@@ -160,6 +160,8 @@
         transition: opacity 0.4s;
       }
       .reveal-lines {
+        position: relative;
+        z-index: 1;
         display: flex;
         flex-direction: column;
         justify-content: center;


### PR DESCRIPTION
## Summary
- ensure the overlay element has a transparent base background so the colored overlay sits behind the text
- keep `color-overlay` below the text container and `reveal-lines` above it

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6865d6d9bd78832fa4ee193137c949ed