### PR TITLE
Allow custom overlay colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ xdg-open index.html        # Linux
 - `date` – additional date or detail line
 - `photo` – URL to an image shown as a circular avatar
 - `from` – a closing signature line
-- `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `none`.
+- `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
 
@@ -34,7 +34,7 @@ index.html?main=We%27re%20Engaged!&sub=Save%20the%20Date&date=June%202024
 ```
 
 ```
-index.html?main=It%27s%20a%20Boy%21&photo=https%3A%2F%2Fexample.com%2Fbaby.jpg&from=Love%2C%20Alice%20and%20Bob&color=blue
+index.html?main=It%27s%20a%20Boy%21&photo=https%3A%2F%2Fexample.com%2Fbaby.jpg&from=Love%2C%20Alice%20and%20Bob&color=coral
 ```
 
 ```

--- a/index.html
+++ b/index.html
@@ -372,16 +372,24 @@
         return lines;
       }
       function getColorOverlay(params) {
-        // Pink, blue, yellow, green, purple, gold, none
-        let color = (params.color || "beige").toLowerCase();
+        // Pink, blue, yellow, green, purple, gold, white, none
+        const input = params.color ? params.color.trim() : "";
+        // Allow custom CSS colors
+        if (isValidHex(input)) return input;
+        const test = new Option().style;
+        test.color = input;
+        if (test.color) return input;
+
+        const color = (input || "beige").toLowerCase();
         const overlays = {
           beige: "rgb(238, 222, 197)",
-          pink: "rgb(249, 185, 215)",
+          pink: "#fcc0c5",
           blue: "rgb(173, 212, 253)",
           yellow: "rgb(254, 243, 199)",
           green: "rgb(203, 247, 208)",
           purple: "rgb(210, 197, 252)",
           gold: "rgb(255, 223, 154)",
+          white: "#ffffff",
           none: "transparent",
         };
         return overlays[color] || overlays.beige;


### PR DESCRIPTION
## Summary
- allow `color` URL param to accept any valid CSS color
- add `white` overlay option and update pink
- document custom color use in README

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_b_6865f30eab28832fb3669be5c9a2d218