### PR TITLE
Update overlay color hex codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,13 +382,13 @@
 
         const color = (input || "beige").toLowerCase();
         const overlays = {
-          beige: "rgb(238, 222, 197)",
+          beige: "#f3ddbb",
           pink: "#fcc0c5",
-          blue: "rgb(173, 212, 253)",
-          yellow: "rgb(254, 243, 199)",
-          green: "rgb(203, 247, 208)",
-          purple: "rgb(210, 197, 252)",
-          gold: "rgb(255, 223, 154)",
+          blue: "#add4fd",
+          yellow: "#fef3c7",
+          green: "#cbf7d0",
+          purple: "#d2c5fc",
+          gold: "#ffdf9a",
           white: "#ffffff",
           none: "transparent",
         };


### PR DESCRIPTION
## Summary
- update the overlay color map to use explicit hex codes

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_b_6865ff949f94832f89df1203d3e222fd