### PR TITLE
Add font query parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ xdg-open index.html        # Linux
 - `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
+- `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)
 
 `color` only affects the overlay background, whereas `textColor` and `outlineColor` control the message text and its outline.
 
@@ -31,6 +32,10 @@ xdg-open index.html        # Linux
 
 ```
 index.html?main=We%27re%20Engaged!&sub=Save%20the%20Date&date=June%202024
+```
+
+```
+index.html?main=We%E2%80%99re%20expecting&font=Playfair+Display
 ```
 
 ```

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/textfit/2.4.0/textFit.min.js"></script>
     <style>
+      :root {
+        --font-family: 'Poppins';
+      }
       html,
       body {
         margin: 0;
@@ -21,7 +24,7 @@
         height: 100%;
         width: 100%;
         background: #f0f0f0;
-        font-family: "Poppins", sans-serif;
+        font-family: var(--font-family), sans-serif;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -183,7 +186,7 @@
         white-space: normal;
         overflow-wrap: break-word;
         text-wrap: balance;
-        font-family: "Poppins", sans-serif;
+        font-family: var(--font-family), sans-serif;
         color: #fff;
         -webkit-text-stroke: 1px #a59079;
         text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
@@ -426,6 +429,19 @@
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
+
+        // Apply custom font
+        if (params.font) {
+          const fontName = params.font.replace(/\+/g, " ");
+          const link = document.createElement("link");
+          link.href = `https://fonts.googleapis.com/css2?family=${params.font}&display=swap`;
+          link.rel = "stylesheet";
+          document.head.appendChild(link);
+          document.documentElement.style.setProperty(
+            "--font-family",
+            `'${fontName}'`,
+          );
+        }
 
 
 


### PR DESCRIPTION
## Summary
- allow customizing the font via new `font` query parameter
- inject Google Fonts stylesheet for the chosen font
- apply the selected font across the page with a CSS variable
- document the new parameter and provide example usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686710541d40832f97779209102358a6