### PR TITLE
Apply consistent text outline styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,9 +215,6 @@
         font-weight: 700;
         font-style: italic;
         margin-top: 0;
-        color: #fff;
-        -webkit-text-stroke: 1px #a59079;
-        text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
       }
       @media (max-width: 500px) {
         .aspect-container {
@@ -644,6 +641,7 @@
               }
               div.style.color = safeTextColor;
               div.style.textShadow = `-1px -1px 0 ${safeOutlineColor}, 1px -1px 0 ${safeOutlineColor}, -1px 1px 0 ${safeOutlineColor}, 1px 1px 0 ${safeOutlineColor}`;
+              div.style.webkitTextStroke = `1px ${safeOutlineColor}`;
               div.style.margin = "0";
               revealLinesDiv.appendChild(div);
               fitRevealLine(div, line.type);
@@ -679,6 +677,7 @@
             div.textContent = mainLine.content;
             div.style.color = safeTextColor;
             div.style.textShadow = `-1px -1px 0 ${safeOutlineColor}, 1px -1px 0 ${safeOutlineColor}, -1px 1px 0 ${safeOutlineColor}, 1px 1px 0 ${safeOutlineColor}`;
+            div.style.webkitTextStroke = `1px ${safeOutlineColor}`;
             introLinesDiv.appendChild(div);
             fitRevealLine(div, "main");
             introOverlay.style.opacity = "1";


### PR DESCRIPTION
## Summary
- set `webkitTextStroke` for all reveal lines in JS
- remove duplicate color/outline styling from `.reveal-line.from`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_686724c6c7e8832fa77a44bc0a0a4c37