### PR TITLE
Clean up reveal-line CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,8 +188,6 @@
         text-wrap: balance;
         font-family: var(--font-family), sans-serif;
         color: #fff;
-        -webkit-text-stroke: 1px #a59079;
-        text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
         margin: 0;
         line-height: 1.15;
       }
@@ -216,16 +214,10 @@
         font-style: italic;
         margin-top: 0;
         color: #fff;
-        -webkit-text-stroke: 1px #a59079;
-        text-shadow: 0 0 1px rgba(0, 0, 0, 0.2);
       }
       @media (max-width: 500px) {
         .aspect-container {
           max-width: 100vw;
-        }
-        .reveal-line {
-          -webkit-text-stroke: 1px #a59079;
-          text-shadow: 0 0 1px rgba(0, 0, 0, 0.15);
         }
         .instructions-container {
           max-width: 96vw;


### PR DESCRIPTION
## Summary
- drop redundant `text-shadow` and `-webkit-text-stroke` from the `.reveal-line` rules so runtime code controls them

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_6867284cd5f8832fac08d320b6b6adf5