### PR TITLE
Animate reels with vertical slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,32 +74,41 @@
         position: absolute;
         width: 19.2%;
         height: 14.4%;
-        top: 34.2%;
         background: transparent;
         display: flex;
         justify-content: center;
         align-items: center;
         z-index: 2;
         transition: filter 0.5s ease;
+        perspective: 600px;
+        overflow: hidden;
       }
       #reel1 {
         left: 20.4%;
+        top: 33.9%;
       }
       #reel2 {
         left: 42.7%;
+        top: 33.7%;
       }
       #reel3 {
         left: 65.1%;
+        top: 33.9%;
       }
       .reel img {
         width: 85%;
         height: 85%;
         object-fit: contain;
+        position: absolute;
+        left: 50%;
+        top: 0;
         display: block;
-        margin: auto;
+        margin: 0;
         background: transparent;
-        transition: transform 0.05s;
         box-shadow: none;
+        backface-visibility: hidden;
+        transform-style: preserve-3d;
+        transform: translate(-50%, 0);
       }
       .spin-button {
         position: absolute;
@@ -563,17 +572,15 @@
                 const frameIndex = Math.floor(progress * maxSpins);
                 if (frameIndex < maxSpins - 1) {
                   img.src = icons[Math.floor(Math.random() * icons.length)];
-                  const scaleEffect =
-                    1 + Math.sin(progress * Math.PI * 8) * 0.04;
-                  img.style.transform = `scale(${scaleEffect})`;
                 } else {
                   img.src = finalIcon;
-                  img.style.transform = "scale(1)";
                 }
+                const offset = -100 + progress * 200;
+                img.style.transform = `translate(-50%, ${offset}%)`;
                 requestAnimationFrame(animate);
               } else {
                 img.src = finalIcon;
-                img.style.transform = "scale(1)";
+                img.style.transform = "translate(-50%, 0)";
                 if (callback && reel === reel3 && progress >= 1)
                   setTimeout(callback, 300);
               }


### PR DESCRIPTION
## Summary
- hide overflow in reel containers for clipping
- position reel images absolutely so they can slide
- translate images vertically during spins rather than rotating

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686739baf690832f8f8fe6c2a6aa6dea