### PR TITLE
Adjust slot machine reel alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,9 @@
         flex-direction: column;
       }
       .reel-strip.stopped {
-        transform: translateY(-75%);
+        /* Shift so the center icon is fully visible with partial items above
+           and below */
+        transform: translateY(-33.333%);
         transition: transform 0.25s ease;
       }
       .reel-strip.stopped .reel-item {


### PR DESCRIPTION
## Summary
- tweak `.reel-strip.stopped` transform so partial icons remain visible

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_686832a503d4832fa28fae9fdc21a0c8