### PR TITLE
Add delay before reveal stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -595,7 +595,13 @@
             const babyBottle = icons[5];
             spinReel(reel1, reel1Delay, spinDuration, babyBottle);
             spinReel(reel2, reel2Delay, spinDuration, babyBottle);
-            spinReel(reel3, reel3Delay, spinDuration, babyBottle, showReveal);
+            spinReel(
+              reel3,
+              reel3Delay,
+              spinDuration,
+              babyBottle,
+              () => setTimeout(showReveal, 1000),
+            );
             currentSymbols = [babyBottle, babyBottle, babyBottle];
           } else {
             generateRandomNonMatchingSymbols();


### PR DESCRIPTION
## Summary
- delay Stage 1 reveal overlay until 1 second after the third reel stops

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686834231ddc832fb3cd1502bc19a1b8