### PR TITLE
Improve reel stop animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         flex-direction: column;
         align-items: center;
         justify-content: flex-start;
-        transition: transform 0.25s linear;
+        transition: transform 0.35s cubic-bezier(0.22, 0.61, 0.36, 1);
       }
       @keyframes slot-spin-down {
         0% {
@@ -446,7 +446,11 @@
         }
 
         function createSingleIcon(reel, icon) {
-          reel.innerHTML = `<div class="reel-inner"><img src="${icon}" alt="Slot Icon"></div>`;
+          reel.innerHTML = `<div class="reel-inner" style="transform: translateY(-100%)"><img src="${icon}" alt="Slot Icon"></div>`;
+          const inner = reel.querySelector('.reel-inner');
+          requestAnimationFrame(() => {
+            inner.style.transform = 'translateY(0)';
+          });
         }
 
         function createReelStrip(reel) {


### PR DESCRIPTION
## Summary
- smooth out the reel stop by easing the transform transition
- slide in the final icon instead of abruptly switching

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6868346c9ed4832fbd844d2ab0a2888c