### PR TITLE
Fix reveal timing after final spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,9 +608,11 @@
             spinReel(reel2, reel2Delay, spinDuration, currentSymbols[1]);
             spinReel(reel3, reel3Delay, spinDuration, currentSymbols[2]);
           }
+          const pointerDelay =
+            reel3Delay + spinDuration + (spinCount === 4 ? 500 : 0);
           setTimeout(() => {
             spinButton.style.pointerEvents = "auto";
-          }, reel3Delay + spinDuration);
+          }, pointerDelay);
         }
         function generateRandomNonMatchingSymbols() {
           let idx = [];


### PR DESCRIPTION
## Summary
- avoid re-enabling the spin button before the reveal starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686837a620f8832f829970727bfa560e