### PR TITLE
Fix word breaking in reveal text

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
         width: 100%;
         text-align: center;
         white-space: normal;
-        overflow-wrap: break-word;
+        overflow-wrap: normal;
         text-wrap: balance;
         font-family: var(--font-family), sans-serif;
         color: #fff;


### PR DESCRIPTION
## Summary
- stop `.reveal-line` from breaking words in the middle so long words fit using textFit

## Testing
- `grep -n "overflow-wrap" -n index.html`

------
https://chatgpt.com/codex/tasks/task_b_6869da161c5c832f88740806ff99a220