### PR TITLE
Add per-line font options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ xdg-open index.html        # Linux
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
 - `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)
+- `fontMain` – font family for the main headline
+- `fontSub` – font family for the secondary line
+- `fontDate` – font family for the date line
+- `fontFrom` – font family for the closing signature
+
+Font parameters expect Google Fonts family names just like `font`, using `+` instead of spaces.
 
 `color` only affects the overlay background, whereas `textColor` and `outlineColor` control the message text and its outline.
 
@@ -36,6 +42,10 @@ index.html?main=We%27re%20Engaged!&sub=Save%20the%20Date&date=June%202024
 
 ```
 index.html?main=We%E2%80%99re%20expecting&font=Playfair+Display
+```
+
+```
+index.html?main=Congrats!&sub=You%20Did%20It&fontMain=Playfair+Display&fontSub=Roboto+Slab
 ```
 
 ```

--- a/index.html
+++ b/index.html
@@ -487,18 +487,36 @@
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
 
-        // Apply custom font
-        if (params.font) {
-          const fontName = params.font.replace(/\+/g, " ");
+        // --------- Font loading logic ---------
+        function loadGoogleFont(familyParam) {
+          if (!familyParam) return null;
+          const familyName = familyParam.replace(/\+/g, " ");
           const link = document.createElement("link");
-          link.href = `https://fonts.googleapis.com/css2?family=${params.font}&display=swap`;
+          link.href = `https://fonts.googleapis.com/css2?family=${familyParam}&display=swap`;
           link.rel = "stylesheet";
           document.head.appendChild(link);
-          document.documentElement.style.setProperty(
-            "--font-family",
-            `'${fontName}'`,
-          );
+          return `'${familyName}'`;
         }
+
+        const fonts = {
+          main: null,
+          sub: null,
+          date: null,
+          from: null,
+        };
+
+        // Global font applied via CSS variable
+        if (params.font) {
+          const ff = loadGoogleFont(params.font);
+          if (ff)
+            document.documentElement.style.setProperty("--font-family", ff);
+          fonts.main = fonts.sub = fonts.date = fonts.from = ff;
+        }
+
+        fonts.main = loadGoogleFont(params.fontmain) || fonts.main;
+        fonts.sub = loadGoogleFont(params.fontsub) || fonts.sub;
+        fonts.date = loadGoogleFont(params.fontdate) || fonts.date;
+        fonts.from = loadGoogleFont(params.fontfrom) || fonts.from;
 
 
 
@@ -660,7 +678,7 @@
           });
         }
 
-        function applyTextStyles(el, color, outlineColor) {
+        function applyTextStyles(el, color, outlineColor, fontFamily) {
           el.style.color = color;
           if (outlineColor === "transparent") {
             el.style.textShadow = "none";
@@ -668,6 +686,9 @@
           } else {
             el.style.textShadow = `-1px -1px 0 ${outlineColor}, 1px -1px 0 ${outlineColor}, -1px 1px 0 ${outlineColor}, 1px 1px 0 ${outlineColor}`;
             el.style.webkitTextStroke = `1px ${outlineColor}`;
+          }
+          if (fontFamily) {
+            el.style.fontFamily = `${fontFamily}, sans-serif`;
           }
         }
 
@@ -697,7 +718,7 @@
                 div.textContent =
                   line.type === "sub" ? line.content.toUpperCase() : line.content;
               }
-              applyTextStyles(div, safeTextColor, safeOutlineColor);
+              applyTextStyles(div, safeTextColor, safeOutlineColor, fonts[line.type]);
               div.style.margin = "0";
               revealLinesDiv.appendChild(div);
               fitRevealLine(div, line.type);
@@ -731,7 +752,7 @@
             const div = document.createElement("div");
             div.className = "reveal-line main";
             div.textContent = mainLine.content;
-            applyTextStyles(div, safeTextColor, safeOutlineColor);
+            applyTextStyles(div, safeTextColor, safeOutlineColor, fonts.main);
             introLinesDiv.appendChild(div);
             fitRevealLine(div, "main");
             introOverlay.style.opacity = "1";


### PR DESCRIPTION
## Summary
- support custom fonts for each text block via `fontMain`, `fontSub`, `fontDate`, and `fontFrom`
- document the new parameters in README with an example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a9f0276b4832f8eaf8691dcf1c70e