### PR TITLE
Support per-line text colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ xdg-open index.html        # Linux
 - `color` – overlay color when the message appears. Allowed values: `beige` (default), `pink`, `blue`, `yellow`, `green`, `purple`, `gold`, `white`, `none`. You can also supply any valid hex or CSS color value for a custom overlay.
 - `textColor` – color for the message text (any valid CSS color value)
 - `outlineColor` – color for the outline around the message text
+- `mainTextColor` – text color for the main headline
+- `mainOutlineColor` – outline color for the main headline
+- `subTextColor` – text color for the secondary line
+- `subOutlineColor` – outline color for the secondary line
+- `dateTextColor` – text color for the date line
+- `dateOutlineColor` – outline color for the date line
+- `fromTextColor` – text color for the closing signature
+- `fromOutlineColor` – outline color for the closing signature
 - `font` – Google Fonts family name to use for all text (e.g. `font=Playfair+Display`)
 - `fontMain` – font family for the main headline
 - `fontSub` – font family for the secondary line
@@ -31,6 +39,8 @@ xdg-open index.html        # Linux
 - `fontFrom` – font family for the closing signature
 
 Font parameters expect Google Fonts family names just like `font`, using `+` instead of spaces.
+
+Line-specific color parameters fall back to `textColor` and `outlineColor` if omitted.
 
 `color` only affects the overlay background, whereas `textColor` and `outlineColor` control the message text and its outline.
 

--- a/index.html
+++ b/index.html
@@ -485,6 +485,25 @@
         const params = getParams();
         const safeTextColor = sanitizeColor(params.textcolor, "#ffffff");
         const safeOutlineColor = sanitizeColor(params.outlinecolor, "#7e5e4f");
+
+        const lineColors = {
+          main: {
+            text: sanitizeColor(params.maintextcolor, safeTextColor),
+            outline: sanitizeColor(params.mainoutlinecolor, safeOutlineColor),
+          },
+          sub: {
+            text: sanitizeColor(params.subtextcolor, safeTextColor),
+            outline: sanitizeColor(params.suboutlinecolor, safeOutlineColor),
+          },
+          date: {
+            text: sanitizeColor(params.datetextcolor, safeTextColor),
+            outline: sanitizeColor(params.dateoutlinecolor, safeOutlineColor),
+          },
+          from: {
+            text: sanitizeColor(params.fromtextcolor, safeTextColor),
+            outline: sanitizeColor(params.fromoutlinecolor, safeOutlineColor),
+          },
+        };
         const audioContext = new (window.AudioContext ||
           window.webkitAudioContext)();
 
@@ -712,7 +731,8 @@
                 div.textContent =
                   line.type === "sub" ? line.content.toUpperCase() : line.content;
               }
-              applyTextStyles(div, safeTextColor, safeOutlineColor, fonts[line.type]);
+              const colors = lineColors[line.type] || { text: safeTextColor, outline: safeOutlineColor };
+              applyTextStyles(div, colors.text, colors.outline, fonts[line.type]);
               div.style.margin = "0";
               revealLinesDiv.appendChild(div);
               fitRevealLine(div, line.type);
@@ -746,7 +766,7 @@
             const div = document.createElement("div");
             div.className = "reveal-line main";
             div.textContent = mainLine.content;
-            applyTextStyles(div, safeTextColor, safeOutlineColor, fonts.main);
+            applyTextStyles(div, lineColors.main.text, lineColors.main.outline, fonts.main);
             introLinesDiv.appendChild(div);
             fitRevealLine(div, "main");
             introOverlay.style.opacity = "1";


### PR DESCRIPTION
## Summary
- add `lineColors` object to apply individual text and outline colors
- document new color parameters in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686c9fdd0368832fa7beab48b6b59e4c