### PR TITLE
Remove copy URL UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,6 @@
         </div>
       </div>
     </div>
-    <button id="copyUrlButton" class="copy-url-button">Copy URL</button>
     <script>
       // -------------- URL Params Logic -------------
       function getParams() {
@@ -920,18 +919,6 @@
               });
             }
           }, 8000);
-        }
-        const copyBtn = document.getElementById("copyUrlButton");
-        if (copyBtn && navigator.clipboard) {
-          copyBtn.addEventListener("click", function (e) {
-            e.preventDefault();
-            navigator.clipboard.writeText(window.location.href).then(() => {
-              copyBtn.textContent = "Copied!";
-              setTimeout(() => {
-                copyBtn.textContent = "Copy URL";
-              }, 2000);
-            });
-          });
         }
         window.addEventListener("resize", refitAllLines);
       });


### PR DESCRIPTION
## Summary
- remove the Copy URL button
- drop clipboard code that handled copying the page URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686ca75dfe98832f920b605597ee4ad6